### PR TITLE
`libdatastore`: add builders for datastore requests

### DIFF
--- a/server_libraries/libdatastore/Cargo.toml
+++ b/server_libraries/libdatastore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nullnet-libdatastore"
-version = "0.4.9"
+version = "0.5.0"
 edition = "2024"
 authors= ["Anton Liashkevich <anton.liashkevich.eng@gmail.com>"]
 repository = "https://github.com/NullNet-ai/libguard"

--- a/server_libraries/libdatastore/src/builders/advanced_filter_builder.rs
+++ b/server_libraries/libdatastore/src/builders/advanced_filter_builder.rs
@@ -1,0 +1,51 @@
+use crate::AdvanceFilter;
+
+#[derive(Debug, Default)]
+pub struct AdvanceFilterBuilder {
+    r#type: String,
+    field: String,
+    operator: String,
+    entity: String,
+    values: String,
+}
+
+impl AdvanceFilterBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn r#type(mut self, value: impl Into<String>) -> Self {
+        self.r#type = value.into();
+        self
+    }
+
+    pub fn field(mut self, value: impl Into<String>) -> Self {
+        self.field = value.into();
+        self
+    }
+
+    pub fn operator(mut self, value: impl Into<String>) -> Self {
+        self.operator = value.into();
+        self
+    }
+
+    pub fn entity(mut self, value: impl Into<String>) -> Self {
+        self.entity = value.into();
+        self
+    }
+
+    pub fn values(mut self, value: impl Into<String>) -> Self {
+        self.values = value.into();
+        self
+    }
+
+    pub fn build(self) -> AdvanceFilter {
+        AdvanceFilter {
+            r#type: self.r#type,
+            field: self.field,
+            operator: self.operator,
+            entity: self.entity,
+            values: self.values,
+        }
+    }
+}

--- a/server_libraries/libdatastore/src/builders/batch_create_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/batch_create_request_builder.rs
@@ -1,0 +1,56 @@
+use crate::{BatchCreateBody, BatchCreateRequest, CreateParams, Query};
+
+#[derive(Debug, Default)]
+pub struct BatchCreateRequestBuilder {
+    table: Option<String>,
+    pluck: Option<String>,
+    durability: Option<String>,
+    records: Option<String>,
+    entity_prefix: Option<String>,
+}
+
+impl BatchCreateRequestBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn table(mut self, table: impl Into<String>) -> Self {
+        self.table = Some(table.into());
+        self
+    }
+
+    pub fn pluck(mut self, pluck: impl Into<String>) -> Self {
+        self.pluck = Some(pluck.into());
+        self
+    }
+
+    pub fn durability(mut self, durability: impl Into<String>) -> Self {
+        self.durability = Some(durability.into());
+        self
+    }
+
+    pub fn records(mut self, records: impl Into<String>) -> Self {
+        self.records = Some(records.into());
+        self
+    }
+
+    pub fn entity_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.entity_prefix = Some(prefix.into());
+        self
+    }
+
+    pub fn build(self) -> BatchCreateRequest {
+        BatchCreateRequest {
+            params: Some(CreateParams {
+                table: self.table.unwrap_or_default(),
+            }),
+            query: Some(Query {
+                pluck: self.pluck.unwrap_or_default(),
+                durability: self.durability.unwrap_or_else(|| "soft".into()),
+            }),
+            body: Some(BatchCreateBody {
+                records: self.records.unwrap_or_default(),
+            }),
+        }
+    }
+}

--- a/server_libraries/libdatastore/src/builders/batch_update_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/batch_update_request_builder.rs
@@ -1,0 +1,64 @@
+use crate::{AdvanceFilter, BatchUpdateBody, BatchUpdateRequest, Params};
+
+#[derive(Debug, Default)]
+pub struct BatchUpdateRequestBuilder {
+    advance_filters: Vec<AdvanceFilter>,
+    updates: Option<String>,
+    id: Option<String>,
+    table: Option<String>,
+    is_root: bool,
+}
+
+impl BatchUpdateRequestBuilder {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    pub fn table(mut self, table: impl Into<String>) -> Self {
+        self.table = Some(table.into());
+        self
+    }
+
+    pub fn advance_filter(mut self, filter: AdvanceFilter) -> Self {
+        self.advance_filters.push(filter);
+        self
+    }
+
+    pub fn advance_filters(mut self, filters: impl IntoIterator<Item = AdvanceFilter>) -> Self {
+        self.advance_filters.extend(filters);
+        self
+    }
+
+    pub fn performed_by_root(mut self, value: bool) -> Self {
+        self.is_root = value;
+        self
+    }
+
+    pub fn updates(mut self, updates: impl Into<String>) -> Self {
+        self.updates = Some(updates.into());
+        self
+    }
+
+    pub fn build(self) -> BatchUpdateRequest {
+        BatchUpdateRequest {
+            params: Some(Params {
+                id: self.id.unwrap_or_default(),
+                table: self.table.unwrap_or_default(),
+                r#type: if self.is_root {
+                    String::from("root")
+                } else {
+                    String::new()
+                },
+            }),
+            body: Some(BatchUpdateBody {
+                advance_filters: self.advance_filters,
+                updates: self.updates.unwrap_or_default(),
+            }),
+        }
+    }
+}

--- a/server_libraries/libdatastore/src/builders/create_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/create_request_builder.rs
@@ -1,0 +1,59 @@
+use crate::{CreateBody, CreateParams, CreateRequest, Query};
+
+#[derive(Debug, Default)]
+pub struct CreateRequestBuilder {
+    table: Option<String>,
+    durability: Option<String>,
+    pluck: Option<String>,
+    record: Option<String>,
+}
+
+impl CreateRequestBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn table(mut self, table: impl Into<String>) -> Self {
+        self.table = Some(table.into());
+        self
+    }
+
+    pub fn durability(mut self, durability: impl Into<String>) -> Self {
+        self.durability = Some(durability.into());
+        self
+    }
+
+    pub fn pluck<I, S>(mut self, fields: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let joined = fields
+            .into_iter()
+            .map(Into::into)
+            .collect::<Vec<_>>()
+            .join(",");
+        self.pluck = Some(joined);
+        self
+    }
+
+    pub fn record(mut self, value: impl Into<String>) -> Self {
+        self.record = Some(value.into());
+        self
+    }
+
+    pub fn build(self) -> CreateRequest {
+        CreateRequest {
+            params: Some(CreateParams {
+                table: self.table.unwrap_or_default(),
+            }),
+            query: Some(Query {
+                pluck: self.pluck.unwrap_or_default(),
+                durability: self.durability.unwrap_or_default(),
+            }),
+            body: Some(CreateBody {
+                record: self.record.unwrap_or_default(),
+            }),
+        }
+    }
+}

--- a/server_libraries/libdatastore/src/builders/delete_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/delete_request_builder.rs
@@ -1,0 +1,55 @@
+use crate::{DeleteQuery, DeleteRequest, Params};
+
+#[derive(Debug, Default)]
+pub struct DeleteRequestBuilder {
+    id: Option<String>,
+    table: Option<String>,
+    is_root: bool,
+    is_permanent: bool,
+}
+
+impl DeleteRequestBuilder {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    pub fn table(mut self, table: impl Into<String>) -> Self {
+        self.table = Some(table.into());
+        self
+    }
+
+    pub fn performed_by_root(mut self, value: bool) -> Self {
+        self.is_root = value;
+        self
+    }
+    pub fn permanent(mut self, val: bool) -> Self {
+        self.is_permanent = val;
+        self
+    }
+
+    pub fn build(self) -> DeleteRequest {
+        DeleteRequest {
+            params: Some(Params {
+                id: self.id.unwrap_or_default(),
+                table: self.table.unwrap_or_default(),
+                r#type: if self.is_root {
+                    String::from("root")
+                } else {
+                    String::new()
+                },
+            }),
+            query: Some(DeleteQuery {
+                is_permanent: if self.is_permanent {
+                    String::from("true")
+                } else {
+                    String::from("false")
+                },
+            }),
+        }
+    }
+}

--- a/server_libraries/libdatastore/src/builders/get_by_filer_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/get_by_filer_request_builder.rs
@@ -1,0 +1,159 @@
+use std::collections::HashMap;
+
+use crate::AdvanceFilter;
+use crate::GetByFilterBody;
+use crate::GetByFilterRequest;
+use crate::Join;
+use crate::MultipleSort;
+use crate::Params;
+
+#[derive(Debug, Default)]
+pub struct GetByFilterRequestBuilder {
+    id: Option<String>,
+    table: Option<String>,
+    pluck: Vec<String>,
+    order_by: Option<String>,
+    limit: Option<i32>,
+    offset: Option<i32>,
+    order_direction: Option<String>,
+    advance_filters: Vec<AdvanceFilter>,
+    joins: Vec<Join>,
+    multiple_sort: Vec<MultipleSort>,
+    pluck_object: HashMap<String, String>,
+    date_format: Option<String>,
+    is_root: bool,
+    is_case_sensitive_sorting: bool,
+}
+
+impl GetByFilterRequestBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    pub fn table(mut self, table: impl Into<String>) -> Self {
+        self.table = Some(table.into());
+        self
+    }
+
+    pub fn pluck(mut self, field: impl Into<String>) -> Self {
+        self.pluck.push(field.into());
+        self
+    }
+
+    pub fn plucks(mut self, fields: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.pluck.extend(fields.into_iter().map(Into::into));
+        self
+    }
+
+    pub fn order_by(mut self, field: impl Into<String>) -> Self {
+        self.order_by = Some(field.into());
+        self
+    }
+
+    pub fn limit(mut self, limit: i32) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    pub fn offset(mut self, offset: i32) -> Self {
+        self.offset = Some(offset);
+        self
+    }
+
+    pub fn order_direction(mut self, direction: impl Into<String>) -> Self {
+        self.order_direction = Some(direction.into());
+        self
+    }
+
+    pub fn advance_filter(mut self, filter: AdvanceFilter) -> Self {
+        self.advance_filters.push(filter);
+        self
+    }
+
+    pub fn advance_filters(mut self, filters: impl IntoIterator<Item = AdvanceFilter>) -> Self {
+        self.advance_filters.extend(filters);
+        self
+    }
+
+    pub fn join(mut self, join: Join) -> Self {
+        self.joins.push(join);
+        self
+    }
+
+    pub fn joins(mut self, joins: impl IntoIterator<Item = Join>) -> Self {
+        self.joins.extend(joins);
+        self
+    }
+
+    pub fn multiple_sort(mut self, sort: MultipleSort) -> Self {
+        self.multiple_sort.push(sort);
+        self
+    }
+
+    pub fn multiple_sorts(mut self, sorts: impl IntoIterator<Item = MultipleSort>) -> Self {
+        self.multiple_sort.extend(sorts);
+        self
+    }
+
+    pub fn pluck_object(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.pluck_object.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn pluck_objects(
+        mut self,
+        entries: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    ) -> Self {
+        for (k, v) in entries {
+            self.pluck_object.insert(k.into(), v.into());
+        }
+        self
+    }
+
+    pub fn date_format(mut self, format: impl Into<String>) -> Self {
+        self.date_format = Some(format.into());
+        self
+    }
+
+    pub fn performed_by_root(mut self, value: bool) -> Self {
+        self.is_root = value;
+        self
+    }
+
+    pub fn case_sensitive_sorting(mut self, value: bool) -> Self {
+        self.is_case_sensitive_sorting = value;
+        self
+    }
+
+    pub fn build(self) -> GetByFilterRequest {
+        GetByFilterRequest {
+            body: Some(GetByFilterBody {
+                pluck: self.pluck,
+                advance_filters: self.advance_filters,
+                order_by: self.order_by.unwrap_or_default(),
+                limit: self.limit.unwrap_or_default(),
+                offset: self.offset.unwrap_or_default(),
+                order_direction: self.order_direction.unwrap_or_default(),
+                joins: self.joins,
+                multiple_sort: self.multiple_sort,
+                pluck_object: self.pluck_object,
+                date_format: self.date_format.unwrap_or_default(),
+                is_case_sensitive_sorting: self.is_case_sensitive_sorting,
+            }),
+            params: Some(Params {
+                id: self.id.unwrap_or_default(),
+                table: self.table.unwrap_or_default(),
+                r#type: if self.is_root {
+                    String::from("root")
+                } else {
+                    String::new()
+                },
+            }),
+        }
+    }
+}

--- a/server_libraries/libdatastore/src/builders/get_by_id_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/get_by_id_request_builder.rs
@@ -1,0 +1,69 @@
+use crate::{GetByIdRequest, Params, Query};
+
+#[derive(Debug, Default)]
+pub struct GetByIdRequestBuilder {
+    id: Option<String>,
+    table: Option<String>,
+    pluck: Option<String>,
+    durability: Option<String>,
+    is_root: bool,
+}
+
+impl GetByIdRequestBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    pub fn table(mut self, table: impl Into<String>) -> Self {
+        self.table = Some(table.into());
+        self
+    }
+
+    pub fn pluck<I, S>(mut self, fields: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let joined = fields
+            .into_iter()
+            .map(Into::into)
+            .collect::<Vec<_>>()
+            .join(",");
+
+        self.pluck = Some(joined);
+        self
+    }
+
+    pub fn durability(mut self, durability: impl Into<String>) -> Self {
+        self.durability = Some(durability.into());
+        self
+    }
+
+    pub fn performed_by_root(mut self, value: bool) -> Self {
+        self.is_root = value;
+        self
+    }
+
+    pub fn build(self) -> GetByIdRequest {
+        GetByIdRequest {
+            params: Some(Params {
+                id: self.id.unwrap_or_default(),
+                table: self.table.unwrap_or_default(),
+                r#type: if self.is_root {
+                    String::from("root")
+                } else {
+                    String::new()
+                },
+            }),
+            query: Some(Query {
+                pluck: self.pluck.unwrap_or_default(),
+                durability: self.durability.unwrap_or_default(),
+            }),
+        }
+    }
+}

--- a/server_libraries/libdatastore/src/builders/login_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/login_request_builder.rs
@@ -1,0 +1,49 @@
+use crate::{LoginBody, LoginData, LoginParams, LoginRequest};
+
+#[derive(Debug, Default)]
+pub struct LoginRequestBuilder {
+    account_id: Option<String>,
+    account_secret: Option<String>,
+    is_root: bool,
+}
+
+impl LoginRequestBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn account_id(mut self, id: impl Into<String>) -> Self {
+        self.account_id = Some(id.into());
+        self
+    }
+
+    pub fn account_secret(mut self, secret: impl Into<String>) -> Self {
+        self.account_secret = Some(secret.into());
+        self
+    }
+
+    pub fn set_root(mut self, is_root: bool) -> Self {
+        self.is_root = is_root;
+        self
+    }
+
+    pub fn build(self) -> LoginRequest {
+        LoginRequest {
+            body: Some(LoginBody {
+                data: Some(LoginData {
+                    account_id: self.account_id.unwrap_or_default(),
+                    account_secret: self.account_secret.unwrap_or_default(),
+                }),
+            }),
+            params: Some(LoginParams {
+                // Only need to do this because datastore defines this parameter as a String
+                is_root: if self.is_root {
+                    String::from("true")
+                } else {
+                    String::from("false")
+                },
+                t: String::new(),
+            }),
+        }
+    }
+}

--- a/server_libraries/libdatastore/src/builders/mod.rs
+++ b/server_libraries/libdatastore/src/builders/mod.rs
@@ -1,0 +1,41 @@
+#[allow(unused)]
+mod advanced_filter_builder;
+#[allow(unused)]
+mod batch_create_request_builder;
+#[allow(unused)]
+mod batch_update_request_builder;
+#[allow(unused)]
+mod create_request_builder;
+#[allow(unused)]
+mod delete_request_builder;
+#[allow(unused)]
+mod get_by_filer_request_builder;
+#[allow(unused)]
+mod get_by_id_request_builder;
+#[allow(unused)]
+mod login_request_builder;
+#[allow(unused)]
+mod register_device_request_builder;
+#[allow(unused)]
+mod update_request_builder;
+
+#[allow(unused)]
+pub use advanced_filter_builder::AdvanceFilterBuilder;
+#[allow(unused)]
+pub use batch_create_request_builder::BatchCreateRequestBuilder;
+#[allow(unused)]
+pub use batch_update_request_builder::BatchUpdateRequestBuilder;
+#[allow(unused)]
+pub use create_request_builder::CreateRequestBuilder;
+#[allow(unused)]
+pub use delete_request_builder::DeleteRequestBuilder;
+#[allow(unused)]
+pub use get_by_filer_request_builder::GetByFilterRequestBuilder;
+#[allow(unused)]
+pub use get_by_id_request_builder::GetByIdRequestBuilder;
+#[allow(unused)]
+pub use login_request_builder::LoginRequestBuilder;
+#[allow(unused)]
+pub use register_device_request_builder::RegisterDeviceRequestBuilder;
+#[allow(unused)]
+pub use update_request_builder::UpdateRequestBuilder;

--- a/server_libraries/libdatastore/src/builders/register_device_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/register_device_request_builder.rs
@@ -1,0 +1,94 @@
+use crate::{RegisterDeviceParams, RegisterDeviceRequest};
+
+#[derive(Debug, Default)]
+pub struct RegisterDeviceRequestBuilder {
+    pub categories: Vec<String>,
+    pub organization_id: Option<String>,
+    pub account_id: Option<String>,
+    pub account_secret: Option<String>,
+    pub is_new_user: bool,
+    pub is_invited: bool,
+    pub role_id: Option<String>,
+    pub account_organization_status: Option<String>,
+    pub account_organization_categories: Vec<String>,
+    pub device_categories: Vec<String>,
+    pub device_id: Option<String>,
+}
+
+impl RegisterDeviceRequestBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn device_id(mut self, device_id: impl Into<String>) -> Self {
+        self.device_id = Some(device_id.into());
+        self
+    }
+
+    pub fn add_category(mut self, category: impl Into<String>) -> Self {
+        self.categories.push(category.into());
+        self
+    }
+
+    pub fn organization_id(mut self, id: impl Into<String>) -> Self {
+        self.organization_id = Some(id.into());
+        self
+    }
+
+    pub fn account_id(mut self, id: impl Into<String>) -> Self {
+        self.account_id = Some(id.into());
+        self
+    }
+
+    pub fn account_secret(mut self, secret: impl Into<String>) -> Self {
+        self.account_secret = Some(secret.into());
+        self
+    }
+
+    pub fn set_is_new_user(mut self, flag: bool) -> Self {
+        self.is_new_user = flag;
+        self
+    }
+
+    pub fn set_is_invited(mut self, flag: bool) -> Self {
+        self.is_invited = flag;
+        self
+    }
+
+    pub fn role_id(mut self, id: impl Into<String>) -> Self {
+        self.role_id = Some(id.into());
+        self
+    }
+
+    pub fn account_organization_status(mut self, status: impl Into<String>) -> Self {
+        self.account_organization_status = Some(status.into());
+        self
+    }
+
+    pub fn add_account_organization_category(mut self, category: impl Into<String>) -> Self {
+        self.account_organization_categories.push(category.into());
+        self
+    }
+
+    pub fn add_device_category(mut self, category: impl Into<String>) -> Self {
+        self.device_categories.push(category.into());
+        self
+    }
+
+    pub fn build(self) -> RegisterDeviceRequest {
+        RegisterDeviceRequest {
+            device: Some(RegisterDeviceParams {
+                organization_id: self.organization_id.unwrap_or_default(),
+                account_id: self.account_id.unwrap_or_default(),
+                account_secret: self.account_secret.unwrap_or_default(),
+                is_new_user: self.is_new_user,
+                is_invited: self.is_invited,
+                role_id: self.role_id.unwrap_or_default(),
+                account_organization_status: self.account_organization_status.unwrap_or_default(),
+                account_organization_categories: self.account_organization_categories,
+                device_categories: self.device_categories,
+                device_id: self.device_id.unwrap_or_default(),
+            }),
+        }
+    }
+}

--- a/server_libraries/libdatastore/src/builders/update_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/update_request_builder.rs
@@ -1,0 +1,62 @@
+use crate::{Params, Query, UpdateRequest};
+
+#[derive(Debug, Default)]
+pub struct UpdateRequestBuilder {
+    id: Option<String>,
+    table: Option<String>,
+    pluck: Option<String>,
+    durability: Option<String>,
+    body: Option<String>,
+    is_root: bool,
+}
+
+impl UpdateRequestBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    pub fn table(mut self, table: impl Into<String>) -> Self {
+        self.table = Some(table.into());
+        self
+    }
+
+    pub fn query(mut self, pluck: impl Into<String>, durability: impl Into<String>) -> Self {
+        self.pluck = Some(pluck.into());
+        self.durability = Some(durability.into());
+        self
+    }
+
+    pub fn body(mut self, body: impl Into<String>) -> Self {
+        self.body = Some(body.into());
+        self
+    }
+
+    pub fn performed_by_root(mut self, value: bool) -> Self {
+        self.is_root = value;
+        self
+    }
+
+    pub fn build(self) -> UpdateRequest {
+        UpdateRequest {
+            params: Some(Params {
+                id: self.id.unwrap_or_default(),
+                table: self.table.unwrap_or_default(),
+                r#type: if self.is_root {
+                    String::from("root")
+                } else {
+                    String::new()
+                },
+            }),
+            query: Some(Query {
+                pluck: self.pluck.unwrap_or_default(),
+                durability: self.durability.unwrap_or_default(),
+            }),
+            body: self.body.unwrap_or_default(),
+        }
+    }
+}

--- a/server_libraries/libdatastore/src/lib.rs
+++ b/server_libraries/libdatastore/src/lib.rs
@@ -11,6 +11,7 @@ mod datastore;
 #[rustfmt::skip]
 #[allow(clippy::pedantic)]
 pub mod store;
+mod builders;
 
 pub use client::DatastoreClient;
 pub use config::DatastoreConfig;

--- a/server_libraries/libdatastore/src/lib.rs
+++ b/server_libraries/libdatastore/src/lib.rs
@@ -18,4 +18,5 @@ pub use config::DatastoreConfig;
 pub use datastore::*;
 pub use response_data::ResponseData;
 
+pub use builders::*;
 pub use experimental::ExperimentalDatastoreClient;


### PR DESCRIPTION
Add builders for datastore requests to `libdatastore` to facilitate shared usage, following @antoncxx's original implementation in https://github.com/NullNet-ai/wallguard