### PR TITLE
`libdatastore`: add more datastore builders

### DIFF
--- a/server_libraries/libdatastore/Cargo.toml
+++ b/server_libraries/libdatastore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nullnet-libdatastore"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 authors= ["Anton Liashkevich <anton.liashkevich.eng@gmail.com>"]
 repository = "https://github.com/NullNet-ai/libguard"

--- a/server_libraries/libdatastore/build.rs
+++ b/server_libraries/libdatastore/build.rs
@@ -8,7 +8,7 @@ fn main() {
     tonic_build::configure()
         .out_dir("./src")
         .compile_protos(
-            &[DATASTORE_PROTOBUF_PATH, /*STORE_PROTOBUF_PATH*/],
+            &[DATASTORE_PROTOBUF_PATH /*STORE_PROTOBUF_PATH*/],
             &[PROTOBUF_DIR_PATH],
         )
         .expect("Protobuf files generation failed");

--- a/server_libraries/libdatastore/src/builders/advanced_filter_builder.rs
+++ b/server_libraries/libdatastore/src/builders/advanced_filter_builder.rs
@@ -1,4 +1,4 @@
-use crate::AdvanceFilter;
+use crate::datastore::AdvanceFilter;
 
 #[derive(Debug, Default)]
 pub struct AdvanceFilterBuilder {

--- a/server_libraries/libdatastore/src/builders/batch_create_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/batch_create_request_builder.rs
@@ -1,4 +1,4 @@
-use crate::{BatchCreateBody, BatchCreateRequest, CreateParams, Query};
+use crate::datastore::{BatchCreateBody, BatchCreateRequest, CreateParams, Query};
 
 #[derive(Debug, Default)]
 pub struct BatchCreateRequestBuilder {

--- a/server_libraries/libdatastore/src/builders/batch_delete_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/batch_delete_request_builder.rs
@@ -1,4 +1,4 @@
-use crate::{AdvanceFilter, BatchDeleteBody, BatchDeleteRequest, Params};
+use crate::datastore::{AdvanceFilter, BatchDeleteBody, BatchDeleteRequest, Params};
 
 #[derive(Debug, Default)]
 pub struct BatchDeleteRequestBuilder {

--- a/server_libraries/libdatastore/src/builders/batch_delete_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/batch_delete_request_builder.rs
@@ -1,0 +1,57 @@
+use crate::{AdvanceFilter, BatchDeleteBody, BatchDeleteRequest, Params};
+
+#[derive(Debug, Default)]
+pub struct BatchDeleteRequestBuilder {
+    id: Option<String>,
+    table: Option<String>,
+    is_root: bool,
+    advance_filters: Vec<AdvanceFilter>,
+}
+
+impl BatchDeleteRequestBuilder {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    pub fn table(mut self, table: impl Into<String>) -> Self {
+        self.table = Some(table.into());
+        self
+    }
+
+    pub fn performed_by_root(mut self, value: bool) -> Self {
+        self.is_root = value;
+        self
+    }
+
+    pub fn advance_filter(mut self, filter: AdvanceFilter) -> Self {
+        self.advance_filters.push(filter);
+        self
+    }
+
+    pub fn advance_filters(mut self, filters: impl IntoIterator<Item = AdvanceFilter>) -> Self {
+        self.advance_filters.extend(filters);
+        self
+    }
+
+    pub fn build(self) -> BatchDeleteRequest {
+        BatchDeleteRequest {
+            params: Some(Params {
+                id: self.id.unwrap_or_default(),
+                table: self.table.unwrap_or_default(),
+                r#type: if self.is_root {
+                    String::from("root")
+                } else {
+                    String::new()
+                },
+            }),
+            body: Some(BatchDeleteBody {
+                advance_filters: self.advance_filters,
+            }),
+        }
+    }
+}

--- a/server_libraries/libdatastore/src/builders/batch_update_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/batch_update_request_builder.rs
@@ -1,4 +1,4 @@
-use crate::{AdvanceFilter, BatchUpdateBody, BatchUpdateRequest, Params};
+use crate::datastore::{AdvanceFilter, BatchUpdateBody, BatchUpdateRequest, Params};
 
 #[derive(Debug, Default)]
 pub struct BatchUpdateRequestBuilder {

--- a/server_libraries/libdatastore/src/builders/create_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/create_request_builder.rs
@@ -1,4 +1,4 @@
-use crate::{CreateBody, CreateParams, CreateRequest, Query};
+use crate::datastore::{CreateBody, CreateParams, CreateRequest, Query};
 
 #[derive(Debug, Default)]
 pub struct CreateRequestBuilder {

--- a/server_libraries/libdatastore/src/builders/delete_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/delete_request_builder.rs
@@ -1,4 +1,4 @@
-use crate::{DeleteQuery, DeleteRequest, Params};
+use crate::datastore::{DeleteQuery, DeleteRequest, Params};
 
 #[derive(Debug, Default)]
 pub struct DeleteRequestBuilder {

--- a/server_libraries/libdatastore/src/builders/get_by_filer_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/get_by_filer_request_builder.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
-use crate::AdvanceFilter;
-use crate::GetByFilterBody;
-use crate::GetByFilterRequest;
-use crate::Join;
-use crate::MultipleSort;
-use crate::Params;
+use crate::datastore::AdvanceFilter;
+use crate::datastore::GetByFilterBody;
+use crate::datastore::GetByFilterRequest;
+use crate::datastore::Join;
+use crate::datastore::MultipleSort;
+use crate::datastore::Params;
 
 #[derive(Debug, Default)]
 pub struct GetByFilterRequestBuilder {

--- a/server_libraries/libdatastore/src/builders/get_by_id_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/get_by_id_request_builder.rs
@@ -1,4 +1,4 @@
-use crate::{GetByIdRequest, Params, Query};
+use crate::datastore::{GetByIdRequest, Params, Query};
 
 #[derive(Debug, Default)]
 pub struct GetByIdRequestBuilder {

--- a/server_libraries/libdatastore/src/builders/join_builder.rs
+++ b/server_libraries/libdatastore/src/builders/join_builder.rs
@@ -1,0 +1,99 @@
+use crate::{AdvanceFilter, EntityFieldFrom, EntityFieldTo, FieldRelation, Join};
+
+#[derive(Debug, Default)]
+pub struct JoinBuilder {
+    r#type: String,
+    to_entity: String,
+    to_field: String,
+    to_alias: String,
+    to_limit: i32,
+    to_order_by: String,
+    to_filters: Vec<AdvanceFilter>,
+    from_entity: String,
+    from_field: String,
+}
+
+impl JoinBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn r#type(mut self, value: impl Into<String>) -> Self {
+        self.r#type = value.into();
+        self
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_entity(mut self, value: impl Into<String>) -> Self {
+        self.to_entity = value.into();
+        self
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_field(mut self, value: impl Into<String>) -> Self {
+        self.to_field = value.into();
+        self
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_alias(mut self, value: impl Into<String>) -> Self {
+        self.to_alias = value.into();
+        self
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_limit(mut self, value: i32) -> Self {
+        self.to_limit = value;
+        self
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_order_by(mut self, value: impl Into<String>) -> Self {
+        self.to_order_by = value.into();
+        self
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_filter(mut self, filter: AdvanceFilter) -> Self {
+        self.to_filters.push(filter);
+        self
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_filters(mut self, filters: impl IntoIterator<Item = AdvanceFilter>) -> Self {
+        self.to_filters.extend(filters);
+        self
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+    pub fn from_entity(mut self, value: impl Into<String>) -> Self {
+        self.from_entity = value.into();
+        self
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+    pub fn from_field(mut self, value: impl Into<String>) -> Self {
+        self.from_field = value.into();
+        self
+    }
+
+    pub fn build(self) -> Join {
+        Join {
+            r#type: self.r#type,
+            field_relation: Some(FieldRelation {
+                to: Some(EntityFieldTo {
+                    entity: self.to_entity,
+                    field: self.to_field,
+                    alias: self.to_alias,
+                    limit: self.to_limit,
+                    order_by: self.to_order_by,
+                    filters: self.to_filters,
+                }),
+                from: Some(EntityFieldFrom {
+                    entity: self.from_entity,
+                    field: self.from_field,
+                }),
+            }),
+        }
+    }
+}

--- a/server_libraries/libdatastore/src/builders/join_builder.rs
+++ b/server_libraries/libdatastore/src/builders/join_builder.rs
@@ -1,4 +1,4 @@
-use crate::{AdvanceFilter, EntityFieldFrom, EntityFieldTo, FieldRelation, Join};
+use crate::datastore::{AdvanceFilter, EntityFieldFrom, EntityFieldTo, FieldRelation, Join};
 
 #[derive(Debug, Default)]
 pub struct JoinBuilder {

--- a/server_libraries/libdatastore/src/builders/login_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/login_request_builder.rs
@@ -1,4 +1,4 @@
-use crate::{LoginBody, LoginData, LoginParams, LoginRequest};
+use crate::datastore::{LoginBody, LoginData, LoginParams, LoginRequest};
 
 #[derive(Debug, Default)]
 pub struct LoginRequestBuilder {

--- a/server_libraries/libdatastore/src/builders/mod.rs
+++ b/server_libraries/libdatastore/src/builders/mod.rs
@@ -15,6 +15,8 @@ mod get_by_filer_request_builder;
 #[allow(unused)]
 mod get_by_id_request_builder;
 #[allow(unused)]
+mod join_builder;
+#[allow(unused)]
 mod login_request_builder;
 #[allow(unused)]
 mod multiple_sort_builder;

--- a/server_libraries/libdatastore/src/builders/mod.rs
+++ b/server_libraries/libdatastore/src/builders/mod.rs
@@ -17,6 +17,8 @@ mod get_by_id_request_builder;
 #[allow(unused)]
 mod login_request_builder;
 #[allow(unused)]
+mod multiple_sort_builder;
+#[allow(unused)]
 mod register_device_request_builder;
 #[allow(unused)]
 mod update_request_builder;

--- a/server_libraries/libdatastore/src/builders/mod.rs
+++ b/server_libraries/libdatastore/src/builders/mod.rs
@@ -32,6 +32,8 @@ pub use advanced_filter_builder::AdvanceFilterBuilder;
 #[allow(unused)]
 pub use batch_create_request_builder::BatchCreateRequestBuilder;
 #[allow(unused)]
+pub use batch_delete_request_builder::BatchDeleteRequestBuilder;
+#[allow(unused)]
 pub use batch_update_request_builder::BatchUpdateRequestBuilder;
 #[allow(unused)]
 pub use create_request_builder::CreateRequestBuilder;
@@ -42,8 +44,14 @@ pub use get_by_filer_request_builder::GetByFilterRequestBuilder;
 #[allow(unused)]
 pub use get_by_id_request_builder::GetByIdRequestBuilder;
 #[allow(unused)]
+pub use join_builder::JoinBuilder;
+#[allow(unused)]
 pub use login_request_builder::LoginRequestBuilder;
+#[allow(unused)]
+pub use multiple_sort_builder::MultipleSortBuilder;
 #[allow(unused)]
 pub use register_device_request_builder::RegisterDeviceRequestBuilder;
 #[allow(unused)]
 pub use update_request_builder::UpdateRequestBuilder;
+#[allow(unused)]
+pub use upsert_request_builder::UpsertRequestBuilder;

--- a/server_libraries/libdatastore/src/builders/mod.rs
+++ b/server_libraries/libdatastore/src/builders/mod.rs
@@ -3,6 +3,8 @@ mod advanced_filter_builder;
 #[allow(unused)]
 mod batch_create_request_builder;
 #[allow(unused)]
+mod batch_delete_request_builder;
+#[allow(unused)]
 mod batch_update_request_builder;
 #[allow(unused)]
 mod create_request_builder;

--- a/server_libraries/libdatastore/src/builders/mod.rs
+++ b/server_libraries/libdatastore/src/builders/mod.rs
@@ -18,6 +18,8 @@ mod login_request_builder;
 mod register_device_request_builder;
 #[allow(unused)]
 mod update_request_builder;
+#[allow(unused)]
+mod upsert_request_builder;
 
 #[allow(unused)]
 pub use advanced_filter_builder::AdvanceFilterBuilder;

--- a/server_libraries/libdatastore/src/builders/multiple_sort_builder.rs
+++ b/server_libraries/libdatastore/src/builders/multiple_sort_builder.rs
@@ -1,0 +1,37 @@
+use crate::MultipleSort;
+
+#[derive(Debug, Default)]
+pub struct MultipleSortBuilder {
+    by_field: String,
+    by_direction: String,
+    is_case_sensitive_sorting: bool,
+}
+
+impl MultipleSortBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn by_field(mut self, value: impl Into<String>) -> Self {
+        self.by_field = value.into();
+        self
+    }
+
+    pub fn by_direction(mut self, value: impl Into<String>) -> Self {
+        self.by_direction = value.into();
+        self
+    }
+
+    pub fn case_sensitive_sorting(mut self, value: bool) -> Self {
+        self.is_case_sensitive_sorting = value;
+        self
+    }
+
+    pub fn build(self) -> MultipleSort {
+        MultipleSort {
+            by_field: self.by_field,
+            by_direction: self.by_direction,
+            is_case_sensitive_sorting: self.is_case_sensitive_sorting,
+        }
+    }
+}

--- a/server_libraries/libdatastore/src/builders/multiple_sort_builder.rs
+++ b/server_libraries/libdatastore/src/builders/multiple_sort_builder.rs
@@ -1,4 +1,4 @@
-use crate::MultipleSort;
+use crate::datastore::MultipleSort;
 
 #[derive(Debug, Default)]
 pub struct MultipleSortBuilder {

--- a/server_libraries/libdatastore/src/builders/register_device_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/register_device_request_builder.rs
@@ -1,4 +1,4 @@
-use crate::{RegisterDeviceParams, RegisterDeviceRequest};
+use crate::datastore::{RegisterDeviceParams, RegisterDeviceRequest};
 
 #[derive(Debug, Default)]
 pub struct RegisterDeviceRequestBuilder {

--- a/server_libraries/libdatastore/src/builders/update_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/update_request_builder.rs
@@ -1,4 +1,4 @@
-use crate::{Params, Query, UpdateRequest};
+use crate::datastore::{Params, Query, UpdateRequest};
 
 #[derive(Debug, Default)]
 pub struct UpdateRequestBuilder {

--- a/server_libraries/libdatastore/src/builders/upsert_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/upsert_request_builder.rs
@@ -1,4 +1,4 @@
-use crate::{Params, Query, UpsertBody, UpsertRequest};
+use crate::datastore::{Params, Query, UpsertBody, UpsertRequest};
 
 #[derive(Debug, Default)]
 pub struct UpsertRequestBuilder {

--- a/server_libraries/libdatastore/src/builders/upsert_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/upsert_request_builder.rs
@@ -47,7 +47,8 @@ impl UpsertRequestBuilder {
         I: IntoIterator<Item = S>,
         S: Into<String>,
     {
-        self.conflict_columns.extend(columns.into_iter().map(|s| s.into()));
+        self.conflict_columns
+            .extend(columns.into_iter().map(|s| s.into()));
         self
     }
 

--- a/server_libraries/libdatastore/src/builders/upsert_request_builder.rs
+++ b/server_libraries/libdatastore/src/builders/upsert_request_builder.rs
@@ -1,0 +1,80 @@
+use crate::{Params, Query, UpsertBody, UpsertRequest};
+
+#[derive(Debug, Default)]
+pub struct UpsertRequestBuilder {
+    id: Option<String>,
+    table: Option<String>,
+    pluck: Option<String>,
+    durability: Option<String>,
+    data: Option<String>,
+    conflict_columns: Vec<String>,
+    is_root: bool,
+}
+
+impl UpsertRequestBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    pub fn table(mut self, table: impl Into<String>) -> Self {
+        self.table = Some(table.into());
+        self
+    }
+
+    pub fn query(mut self, pluck: impl Into<String>, durability: impl Into<String>) -> Self {
+        self.pluck = Some(pluck.into());
+        self.durability = Some(durability.into());
+        self
+    }
+
+    pub fn data(mut self, data: impl Into<String>) -> Self {
+        self.data = Some(data.into());
+        self
+    }
+
+    pub fn conflict_column(mut self, column: impl Into<String>) -> Self {
+        self.conflict_columns.push(column.into());
+        self
+    }
+
+    pub fn conflict_columns<I, S>(mut self, columns: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.conflict_columns.extend(columns.into_iter().map(|s| s.into()));
+        self
+    }
+
+    pub fn performed_by_root(mut self, value: bool) -> Self {
+        self.is_root = value;
+        self
+    }
+
+    pub fn build(self) -> UpsertRequest {
+        UpsertRequest {
+            params: Some(Params {
+                id: self.id.unwrap_or_default(),
+                table: self.table.unwrap_or_default(),
+                r#type: if self.is_root {
+                    String::from("root")
+                } else {
+                    String::new()
+                },
+            }),
+            query: Some(Query {
+                pluck: self.pluck.unwrap_or_default(),
+                durability: self.durability.unwrap_or_default(),
+            }),
+            body: Some(UpsertBody {
+                data: self.data.unwrap_or_default(),
+                conflict_columns: self.conflict_columns,
+            }),
+        }
+    }
+}

--- a/server_libraries/libdatastore/src/client.rs
+++ b/server_libraries/libdatastore/src/client.rs
@@ -298,7 +298,7 @@ impl DatastoreClient {
         &mut self,
         request: RegisterDeviceRequest,
         token: &str,
-    ) -> Result<Response, Error> {
+    ) -> Result<ResponseData, Error> {
         let request = authorize_request(request, token)?;
 
         let response = self
@@ -307,6 +307,6 @@ impl DatastoreClient {
             .await
             .handle_err(location!())?;
 
-        Ok(response.into_inner())
+        validate_response_and_convert_to_reponse_data(response.get_ref())
     }
 }

--- a/server_libraries/libdatastore/src/lib.rs
+++ b/server_libraries/libdatastore/src/lib.rs
@@ -5,17 +5,16 @@ mod response_data;
 mod utils;
 
 #[rustfmt::skip]
-#[allow(clippy::pedantic)]
+#[allow(clippy::pedantic, dead_code)]
 mod datastore;
 
 #[rustfmt::skip]
-#[allow(clippy::pedantic)]
-pub mod store;
+#[allow(clippy::pedantic, dead_code)]
+mod store;
 mod builders;
 
 pub use client::DatastoreClient;
 pub use config::DatastoreConfig;
-pub use datastore::*;
 pub use response_data::ResponseData;
 
 pub use builders::*;

--- a/server_libraries/libdatastore/src/utils.rs
+++ b/server_libraries/libdatastore/src/utils.rs
@@ -1,4 +1,5 @@
-use crate::{Response, ResponseData};
+use crate::{ResponseData};
+use crate::datastore::Response;
 use nullnet_liberror::{Error, ErrorHandler, Location, location};
 use std::str::FromStr;
 use tonic::{Request, metadata::MetadataValue};


### PR DESCRIPTION
Add more datastore builders to `libdatastore`:
- `JoinBuilder`
- `MultipleSortBuilder`
- `UpsertRequestBuilder`
- `BatchDeleteRequestBuilder`

This PR also makes private the `datastore` module and fixes the `register_device` to return `ResponseData` instead of `Response`.